### PR TITLE
Fixes lines (edges) visibility issue

### DIFF
--- a/src/components/NFAVisualizer.tsx
+++ b/src/components/NFAVisualizer.tsx
@@ -23,6 +23,8 @@ const NFAVisualizer = ({ nfa }) => {
 
     // Convert NFA to ReactFlow nodes and edges
     const { nodes: nfaNodes, edges: nfaEdges } = convertNFAToReactFlow(nfa);
+    console.log("Nodes:", nfaNodes);
+    console.log("Edges:", nfaEdges);
     
     setNodes(nfaNodes);
     setEdges(nfaEdges);
@@ -38,6 +40,8 @@ const NFAVisualizer = ({ nfa }) => {
   if (!nfa) {
     return <EmptyStateDisplay />;
   }
+
+
 
   const nodeTypes = {
     nfaState: NFAStateNode,
@@ -56,16 +60,16 @@ const NFAVisualizer = ({ nfa }) => {
           type: 'default',
           markerEnd: {
             type: MarkerType.Arrow,
-            color: '#22c55e',
-            width: 20,
-            height: 20,
+            color: '#3b82f6',
+            width: 10,
+            height: 10,
           },
           style: { 
-            stroke: '#22c55e', 
-            strokeWidth: 5 
+            stroke: '#3b82f6', 
+            strokeWidth: 5
           },
           labelBgStyle: { 
-            fill: 'white', 
+            fill: '#ffffff', 
             fillOpacity: 1,
             borderRadius: 4
           },
@@ -77,7 +81,7 @@ const NFAVisualizer = ({ nfa }) => {
           },
         }}
       >
-        <Background color="#f1f5f9" gap={16} />
+        <Background color="#ffffff" gap={16} />
         <Controls />
         <NFAInfoPanel />
       </ReactFlow>

--- a/src/components/nfa/NFAConverterUtils.ts
+++ b/src/components/nfa/NFAConverterUtils.ts
@@ -1,5 +1,7 @@
 
 import { MarkerType } from "@xyflow/react";
+import { format } from "node:path/win32";
+import '@xyflow/react/dist/style.css';
 
 interface NFA {
   states: number[];
@@ -15,6 +17,8 @@ export interface FlowNode {
   data: any;
   position: { x: number; y: number };
   style?: Record<string, any>;
+  sourcePosition?: string;
+  targetPosition?: string;
 }
 
 export interface FlowEdge {
@@ -29,7 +33,6 @@ export interface FlowEdge {
   markerEnd?: any;
   labelBgStyle?: Record<string, any>;
   labelBgPadding?: number[];
-  sourceHandle?: string;
 }
 
 // Helper function to create a more symmetrical layout for NFA visualization
@@ -189,7 +192,9 @@ export const convertNFAToReactFlow = (nfa: NFA | null) => {
         isInitial,
         isAccepting
       },
-      position: position
+      position: position,
+      sourcePosition: 'right',
+      targetPosition: 'left',
     };
   });
 
@@ -210,6 +215,7 @@ export const convertNFAToReactFlow = (nfa: NFA | null) => {
         border: "none",
         background: "transparent",
       },
+      sourcePosition: 'right',
     });
   }
 
@@ -222,11 +228,12 @@ export const convertNFAToReactFlow = (nfa: NFA | null) => {
       id: 'initial-edge',
       source: 'initial-indicator',
       target: nfa.initialState.toString(),
+      label: 'start',
       type: 'default',
-      style: { stroke: '#22c55e', strokeWidth: 5 },
+      style: { stroke: '#3b82f6', strokeWidth: 3 },
       markerEnd: {
         type: MarkerType.Arrow,
-        color: '#22c55e',
+        color: '#3b82f6',
         width: 20,
         height: 20,
       },
@@ -254,13 +261,13 @@ export const convertNFAToReactFlow = (nfa: NFA | null) => {
             fill: '#000000', // Black text for better visibility
           },
           style: {
-            stroke: isEpsilon ? '#6b7280' : '#22c55e',
-            strokeWidth: 5, // Much thicker lines for better visibility
+            stroke: isEpsilon ? '#6b7280' : '#3b82f6',
+            strokeWidth: 3, // Much thicker lines for better visibility
             strokeDasharray: isEpsilon ? '5,5' : 'none',
           },
           markerEnd: {
             type: MarkerType.Arrow,
-            color: isEpsilon ? '#6b7280' : '#22c55e',
+            color: isEpsilon ? '#6b7280' : '#3b82f6',
             width: 20,
             height: 20,
           },

--- a/src/components/nfa/NFAStateNode.tsx
+++ b/src/components/nfa/NFAStateNode.tsx
@@ -1,6 +1,6 @@
 
 import React from "react";
-
+import { Handle, Position } from '@xyflow/react'
 interface NFAStateNodeProps {
   data: {
     label: string;
@@ -19,7 +19,22 @@ const NFAStateNode = ({ data }: NFAStateNodeProps) => {
       border-2 border-green-600
       ${isAccepting ? "ring-4 ring-green-600 ring-offset-2" : ""}
     `}>
+      {/* Target Handle - left side */}
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="target"
+        style={{ background: '#555'}}
+      />
       <div className="text-lg font-bold text-black">{label}</div>
+
+      {/* Source Handle - right side */}
+      <Handle 
+        type="source"
+        position={Position.Right}
+        id="source"
+        style={{ background: '#555'}}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Fixes #1 

This PR fixes the issue where edges were not properly connecting to or displaying from custom NFA state nodes (NFAStateNode). The root cause was the absence of anchor points (<Handle /> components) that React Flow uses to attach edges to nodes — even when the handles are not meant to be visible.

React Flow requires nodes to define explicit connection points, typically using <Handle />. Although we’re not using visible handles in the UI, omitting them entirely prevents edges from rendering or positioning correctly.

**What was added/modified:**

In the NFAStateNode component:
- Added Handle components for both incoming and outgoing connections.

Edges Styling:
- Stroke Width: 3
- Blue color (#3b82f6)